### PR TITLE
PVector is float x, y, z container!

### DIFF
--- a/src/vector.js
+++ b/src/vector.js
@@ -97,8 +97,8 @@ function vectorClass($gbl, $loc) {
     $loc.set = makeFunc(vectorSet, "set", [
         self,
         { "x": [ int_, float_ ] },
-        { "x": [ int_, float_ ], optional },
-        { "x": [ int_, float_ ], optional }
+        { "y": [ int_, float_ ], optional },
+        { "z": [ int_, float_ ], optional }
     ]);
 
     $loc.mag = makeFunc(self => self.v.mag(), "mag", [ self ]);

--- a/src/vector.js
+++ b/src/vector.js
@@ -76,9 +76,9 @@ function vectorLimit(self, value) {
 function vectorClass($gbl, $loc) {
     $loc.__init__ = makeFunc(vectorInit, "__init__", [
         self,
-        { "x": int_, optional },
-        { "y": int_, optional },
-        { "z": int_, optional }
+        { "x": [ int_, float_ ], optional },
+        { "y": [ int_, float_ ], optional },
+        { "z": [ int_, float_ ], optional }
     ]);
 
     $loc.__getattr__ = new Sk.builtin.func(function (self, key) {
@@ -96,9 +96,9 @@ function vectorClass($gbl, $loc) {
 
     $loc.set = makeFunc(vectorSet, "set", [
         self,
-        { "x": int_ },
-        { "x": int_, optional },
-        { "x": int_, optional }
+        { "x": [ int_, float_ ] },
+        { "x": [ int_, float_ ], optional },
+        { "x": [ int_, float_ ], optional }
     ]);
 
     $loc.mag = makeFunc(self => self.v.mag(), "mag", [ self ]);


### PR DESCRIPTION
http://Processing.GitHub.io/processing-javadocs/core/processing/core/PVector.html

The way class PVector is defined in Trinket now makes it 100% useless!

I can't convert Processing's Python Mode sketches to Trinket b/c its fields are declared as datatype int:
* https://GitHub.com/trinketapp/processing.sk/blob/0.0.12/src/vector.js#L76-L82
* https://GitHub.com/trinketapp/processing.sk/blob/0.0.12/src/vector.js#L97-L102

Dunno whether this repo is active in order to apply this `int_` to `[ int_, float_ ]` urgent fix.